### PR TITLE
Add RDS resources for Artifactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,23 +31,33 @@ After specifying the required inputs, invoke the following commands:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| allocated\_storage | The amount of storage (in gibibytes) to allocate for the DB instance | string | `"20"` | no |
 | allow\_ssh | Whether the user can use SSH | string | `"false"` | no |
 | associate\_public\_ip\_address | Specifies whether to assign a public IP address to each instance | string | `"false"` | no |
 | autoscaling\_group\_name | The name of the Auto Scaling group | string | `"artifactory"` | no |
+| backup\_retention\_period | The number of days for which automated backups are retained. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups | string | `"1"` | no |
 | cidr\_block | The IPv4 network range for the VPC, in CIDR notation | string | n/a | yes |
 | create\_key\_pair | Creates a 2048-bit RSA key pair with the specified name | string | `"false"` | no |
 | create\_nat\_gateway | Creates a NAT gateway in the specified public subnet | string | `"true"` | no |
 | create\_vpc | Creates a VPC with the specified IPv4 CIDR block | string | `"true"` | no |
+| db\_instance\_class | The compute and memory capacity of the DB instance | string | n/a | yes |
+| db\_parameter\_group\_family | The DB parameter group family name | string | `"mysql5.7"` | no |
 | desired\_capacity | The number of EC2 instances that should be running in the group | string | `""` | no |
 | enable\_bastion | Create the bastion host | string | `"false"` | no |
 | enable\_dns\_hostnames | Indicates whether the instances launched in the VPC get DNS hostnames | string | `"true"` | no |
 | enable\_logging | Enable CloudWatch Logs | string | `"true"` | no |
+| engine | The name of the database engine to be used for this instance | string | `"mysql"` | no |
+| engine\_version | The version number of the database engine to use | string | `"5.7.25"` | no |
 | health\_check\_type | The service to use for the health checks | string | `"EC2"` | no |
 | instance\_type | The instance type of the EC2 instance | string | n/a | yes |
 | key\_name | The name of the key pair | string | `""` | no |
+| major\_engine\_version | Specifies the major version of the engine that this option group should be associated with | string | `"5.7"` | no |
 | map\_public\_ip\_on\_launch | Indicates whether instances launched in this subnet receive a public IPv4 address | string | `"false"` | no |
+| master\_user\_password | The password for the master user | string | `""` | no |
 | max\_size | The maximum size of the group | string | n/a | yes |
 | min\_size | The minimum size of the group | string | n/a | yes |
+| port | The port number on which the database accepts connections | string | `"3306"` | no |
+| preferred\_maintenance\_window | The time range each week during which system maintenance can occur, in Universal Coordinated Time (UTC) | string | `""` | no |
 | subnets | The IDs of the public subnets | list | `[]` | no |
 | vpc\_id | The ID of the VPC | string | `""` | no |
 | vpc\_zone\_identifier | A comma-separated list of subnet IDs for your virtual private cloud (VPC) | list | `[]` | no |

--- a/templates/mysql.properties.tpl
+++ b/templates/mysql.properties.tpl
@@ -1,0 +1,25 @@
+#
+#
+# Artifactory is a binaries repository manager.
+# Copyright (C) 2018 JFrog Ltd.
+#
+# Artifactory is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+# Artifactory is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Artifactory.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+type=mysql
+driver=com.mysql.jdbc.Driver
+url=jdbc:mysql://${hosts}/${database}?characterEncoding=UTF-8&elideSetAutoCommits=true&useSSL=false
+username=${user}
+password=${password}

--- a/templates/user-data.txt.tpl
+++ b/templates/user-data.txt.tpl
@@ -19,6 +19,12 @@ write_files:
     path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
     permissions: 0644
 
+  - content: ${artifactory}
+    encoding: b64
+    owner: root:root
+    path: /opt/jfrog/artifactory/etc/db.properties
+    permissions: 0644
+
 yum_repos:
   bintray-jfrog-artifactory-pro-rpms:
     baseurl: https://jfrog.bintray.com/artifactory-pro-rpms

--- a/test/terraform_autoscaling_test.go
+++ b/test/terraform_autoscaling_test.go
@@ -35,6 +35,7 @@ func TestArtifactoryAutoScalingGroup(t *testing.T) {
 			"associate_public_ip_address": true,
 			"cidr_block":                  "10.0.0.0/16",
 			"create_key_pair":             false,
+			"db_instance_class":           "db.t2.micro",
 			"instance_type":               "t2.medium",
 			"key_name":                    keyPair.Name,
 			"max_size":                    1,

--- a/variables.tf
+++ b/variables.tf
@@ -98,3 +98,53 @@ variable "subnets" {
   description = "The IDs of the public subnets"
   type        = "list"
 }
+
+# Relational Database Service Variables
+variable "allocated_storage" {
+  default     = 20
+  description = "The amount of storage (in gibibytes) to allocate for the DB instance"
+}
+
+variable "backup_retention_period" {
+  default     = 1
+  description = "The number of days for which automated backups are retained. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups"
+}
+
+variable "db_instance_class" {
+  description = "The compute and memory capacity of the DB instance"
+}
+
+variable "db_parameter_group_family" {
+  default     = "mysql5.7"
+  description = "The DB parameter group family name"
+}
+
+variable "engine" {
+  default     = "mysql"
+  description = "The name of the database engine to be used for this instance"
+}
+
+variable "engine_version" {
+  default     = "5.7.25"
+  description = "The version number of the database engine to use"
+}
+
+variable "major_engine_version" {
+  default     = "5.7"
+  description = "Specifies the major version of the engine that this option group should be associated with"
+}
+
+variable "master_user_password" {
+  default     = ""
+  description = "The password for the master user"
+}
+
+variable "port" {
+  default     = 3306
+  description = "The port number on which the database accepts connections"
+}
+
+variable "preferred_maintenance_window" {
+  default     = ""
+  description = "The time range each week during which system maintenance can occur, in Universal Coordinated Time (UTC)"
+}


### PR DESCRIPTION
### Description

This pull request adds resources to create an RDS instance using the MySQL engine. The Artifactory database configuration file is dynamically generated based on the metadata associated with the RDS instance (e.g., the RDS instance endpoint, the RDS instance port, and the RDS instance master user).

### Resources Affected

None

### Verification Instructions

    $ go test -timeout 30m -v ./...

Resolves: #10 
